### PR TITLE
📆 Look after listeners on event emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,19 @@ Control handlers for an event set on an [EventEmitter](https://nodejs.org/api/ev
 
 ## Usage
 
+### TL;DR
 ```js
 const Custodian = require('event-custodian');
+new Custodian(emitter, 'event').mount().on('error', (error) => logger.error(error));
+
+// Example: Avoid errors in events that can cause the process to exit with SIGTERM
+new Custodian(process, 'unhandledRejection').mount().on('error', (error) => console.error(error));
 ```
 
-## TL;DR
-```
-new Custodian(emitter, 'event').mount().on('error', (error) => logger.error(error());
-
-// Avoid errors in events that can cause the process to exit with SIGTERM
-new Custodian(process, 'unhandledRejection').mount().on('error', (error) => logger.error(error());
-```
-
-## Reason
+## Motivation
 By overriding native behaviour we can verify existing event handlers run in a safe environment, within a try/catch block. This way we can avoid unexpected results, such as the process exiting unexpectedly within an event handler. We can later decide how we want to handle these errors by placing a general onerror handler on the custodian.
 
 ## Detailed example using process and "unhandledRejection"
-
 ```js
 // Reduce all existing listeners to one
 const custodian = new Custodian(process, 'unhandledRejection');

--- a/README.md
+++ b/README.md
@@ -1,38 +1,47 @@
 # event-custodian [![](https://img.shields.io/npm/v/event-custodian.svg)](https://www.npmjs.com/package/event-custodian) [![](https://img.shields.io/badge/source--000000.svg?logo=github&style=social)](https://github.com/fiverr/event-custodian) [![](https://circleci.com/gh/fiverr/event-custodian.svg?style=svg)](https://circleci.com/gh/fiverr/event-custodian)
-## Control handlers for an event on an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
+
+Control handlers for an event set on an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
+
+## Usage
 
 ```js
 const Custodian = require('event-custodian');
 ```
 
-Reduce all existing listeners to one
+## TL;DR
+```
+new Custodian(emitter, 'event').mount().on('error', (error) => logger.error(error());
+
+// Avoid errors in events that can cause the process to exit with SIGTERM
+new Custodian(process, 'unhandledRejection').mount().on('error', (error) => logger.error(error());
+```
+
+## Reason
+By overriding native behaviour we can verify existing event handlers run in a safe environment, within a try/catch block. This way we can avoid unexpected results, such as the process exiting unexpectedly within an event handler. We can later decide how we want to handle these errors by placing a general onerror handler on the custodian.
+
+## Detailed example using process and "unhandledRejection"
+
 ```js
+// Reduce all existing listeners to one
 const custodian = new Custodian(process, 'unhandledRejection');
-```
 
-Override native event subscription functions
-```js
+// Reduce all existing listeners to one
 custodian.mount();
-```
 
-Handle errors coming up from registered handlers
-```js
+// Handle errors coming up from registered handlers
 custodian.on('error', (error) => logger.error(error));
-```
 
-Add, prepend, remove event handlers as normal
-```js
+// Add, prepend, remove event handlers as normal
 process.on('unhandledRejection', console.error)
     .prependListener('unhandledRejection', (error) => { ... })
     .off('unhandledRejection', console.error)
     .removeAllListeners('unhandledRejection');
-```
-Custodian is now managing the call stack
 
-Revert to native subscription functions (remove override). Reinstate all existing handlers as individual event handlers
-```js
+// Custodian is now managing the call stack
+
+// Revert to native subscription functions (remove override). Reinstate all existing handlers as individual event handlers
 custodian.unmount();
 ```
 
 ### Important note about 'unhandledRejection'
-If you use this application to manage 'unhandledRejection', you **must** set an on('error') handler. Otherwise the custodian will simply print the errors onto console.error.
+If you use this application to manage `unhandledRejection`, you **must** set an `on('error')` handler. Otherwise the custodian will simply print the errors onto `console.error`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Reduce all existing listeners to one
 const custodian = new Custodian(process, 'unhandledRejection');
 ```
 
-Override event subscriptions
+Override native event subscription functions
 ```js
 custodian.mount();
 ```
@@ -29,7 +29,7 @@ process.on('unhandledRejection', console.error)
 ```
 Custodian is now managing the call stack
 
-Remove function override. Return all existing handlers as individual event handlers
+Revert to native subscription functions (remove override). Reinstate all existing handlers as individual event handlers
 ```js
 custodian.unmount();
 ```

--- a/README.md
+++ b/README.md
@@ -3,42 +3,36 @@
 
 ```js
 const Custodian = require('event-custodian');
+```
 
-// Reduce all existing listeners to one
+Reduce all existing listeners to one
+```js
 const custodian = new Custodian(process, 'unhandledRejection');
 ```
 
-Add a handler before all others
+Override event subscriptions
 ```js
-custodian.prepend(
-    (error) => process.stdout.write(
-        JSON.stringify(
-            error instanceof Error
-                ? { level: 'critical', message: error.message, stack: error.stack, code: error.code }
-                : { level: 'critical', message: `Unhandled rejection. Rejected with ${error}` }
-        )
-    )
-);
-```
-
-Add a handler last
-```js
-custodian.append(() => console.log('{"message":"I am also here"}'));
-```
-
-Normal event handlers will be append (on poll stage)
-```js
-process.on('unhandledRejection', (error) => logger.error(error));
-```
-
-Remove all existing handlers
-```js
-custodian.purge();
+custodian.mount();
 ```
 
 Handle errors coming up from registered handlers
 ```js
 custodian.on('error', (error) => logger.error(error));
 ```
+
+Add, prepend, remove event handlers as normal
+```js
+process.on('unhandledRejection', console.error)
+    .prepend('unhandledRejection', (error) => { ... })
+    .off('unhandledRejection', console.error)
+    .removeAllListeners('unhandledRejection');
+```
+Custodian is now managing the call stack
+
+Remove function override. Return all existing handlers as individual event handlers
+```js
+custodian.unmount();
+```
+
 ### Important note about 'unhandledRejection'
 If you use this application to manage 'unhandledRejection', you **must** set an on('error') handler. Otherwise the custodian will simply print the errors onto console.error.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# event-custodian
+# event-custodian [![](https://img.shields.io/npm/v/event-custodian.svg)](https://www.npmjs.com/package/event-custodian) [![](https://img.shields.io/badge/source--000000.svg?logo=github&style=social)](https://github.com/fiverr/event-custodian) [![](https://circleci.com/gh/fiverr/event-custodian.svg?style=svg)](https://circleci.com/gh/fiverr/event-custodian)
+## Control handlers for an event on an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
+
+```js
+const Custodian = require('event-custodian');
+
+// Reduce all existing listeners to one
+const custodian = new Custodian(process, 'unhandledRejection');
+```
+
+Add a handler before all others
+```js
+custodian.prepend(
+    (error) => process.stdout.write(
+        JSON.stringify(
+            error instanceof Error
+                ? { level: 'critical', message: error.message, stack: error.stack, code: error.code }
+                : { level: 'critical', message: `Unhandled rejection. Rejected with ${error}` }
+        )
+    )
+);
+```
+
+Add a handler last
+```js
+custodian.append(() => console.log('{"message":"I am also here"}'));
+```
+
+Normal event handlers will be append (on poll stage)
+```js
+process.on('unhandledRejection', (error) => logger.error(error));
+```
+
+Remove all existing handlers
+```js
+custodian.purge();
+```
+
+Handle errors coming up from registered handlers
+```js
+custodian.on('error', (error) => logger.error(error));
+```
+### Important note about 'unhandledRejection'
+If you use this application to manage 'unhandledRejection', you **must** set an on('error') handler. Otherwise the custodian will simply print the errors onto console.error.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ custodian.on('error', (error) => logger.error(error));
 Add, prepend, remove event handlers as normal
 ```js
 process.on('unhandledRejection', console.error)
-    .prepend('unhandledRejection', (error) => { ... })
+    .prependListener('unhandledRejection', (error) => { ... })
     .off('unhandledRejection', console.error)
     .removeAllListeners('unhandledRejection');
 ```

--- a/index.js
+++ b/index.js
@@ -171,12 +171,11 @@ module.exports = class Custodian {
         aliases.forEach(
             (alias) => {
                 this.mounted[alias] = this.emitter[alias];
-                this.emitter[alias] = (...args) => {
-                    const [ type ] = args;
+                this.emitter[alias] = (type, ...args) => {
                     if (type !== this.type) {
                         return this.mounted[alias].call(this.emitter, this.type, ...args);
                     }
-                    implementation.apply(this, args);
+                    implementation.call(this, type, ...args);
                     return this.emitter;
                 };
             }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const EventEmitter = require('events');
 * @property {string|symbol} type Event type
 * @property {EventEmitter}  events Internal custodian instance events
 * @property {function[]}    handlers Collection of functions to execute when event is fired
-* @property {<string, function>{}} mounted Named collection of original emitter functions
+* @property {<string, function>{}} mounted Named collection of native emitter functions
 * @returns {Custodian}
 */
 module.exports = class Custodian {
@@ -22,9 +22,11 @@ module.exports = class Custodian {
         this.handler = (...args) => {
             const errors = [];
 
-            // Run each handler in it's own quarantine. Collect errors
-            this.handlers.forEach(
+            // Iterating a copy of the handlers guarantees any mutation of the handler collection
+            // will only take affect the next time this event is emitted
+            [ ...this.handlers ].forEach(
                 (handler) => {
+                    // Run each handler in it's own quarantine. Collect errors
                     try {
                         handler.apply(this.emitter, args);
                     } catch (error) {
@@ -52,7 +54,7 @@ module.exports = class Custodian {
     }
 
     /**
-     * Reinstate original event listener
+     * Reinstate native event listener
      * @returns {self}
      */
     unmount() {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,11 @@ module.exports = class Custodian {
                 if (errors.length) {
 
                     // avoid unhandledRejection loop if no handler was registered
-                    if (/unhandledRejection/i.test(name) && this.events.listenerCount('error') === 0) {
+                    if (
+                        emitter === process &&
+                        /unhandledRejection/i.test(name) &&
+                        this.events.listenerCount('error') === 0
+                    ) {
                         this.events.on('error', (error) => console.error(error));
                     }
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,126 @@
-module.exports = null;
+const EventEmitter = require('events');
+
+/**
+* Remove all listerners from an event emitter by type
+* @property {array} handlers Collection of functions to execute when event is fired
+* @property {EventEmitter} events The EventEmitter we monitor
+* @returns {Custodian}
+*/
+module.exports = class Custodian {
+
+    /**
+     * @param {EventEmitter} emitter
+     * @param {string|symbol} name The name of the event being listened for
+     */
+    constructor(emitter, name) {
+        this.handlers = emitter.listeners(name);
+        this.events = new EventEmitter();
+
+        // Remove all existing listeners
+        emitter.removeAllListeners(name);
+
+        // Set our own listener which controls the handlers execution
+        emitter.on(
+            name,
+            (...args) => {
+                const errors = [];
+
+                // Run each handler in it's own quarantine. Collect errors
+                this.handlers.forEach(
+                    (handler) => {
+                        try {
+                            handler.apply(emitter, args);
+                        } catch (error) {
+                            errors.push(error);
+                        }
+                    }
+                );
+                if (errors.length) {
+
+                    // avoid unhandledRejection loop if no handler was registered
+                    if (/unhandledRejection/i.test(name) && this.events.listenerCount('error') === 0) {
+                        this.events.on('error', (error) => console.error(error));
+                    }
+
+                    // Running over all handlers for each error O(n²)
+                    errors.forEach(
+                        (error) => this.events.emit('error', error)
+                    );
+                }
+            }
+        );
+
+        // Monitor for future listener subscriptions
+        emitter.on(
+            'newListener',
+            (event, handler) => {
+                if (event === name) {
+
+                    // Here we are being notified that this will be attached, however, it is not yet attached until poll stage, and then we'll pick it up
+                    setImmediate(() => {
+
+                        // Add to handlers
+                        this.append(handler);
+
+                        // Remove as independent listener
+                        emitter.removeListener(event, handler);
+                    });
+                }
+            }
+        );
+    }
+
+    /**
+     * Add handler at the top of the stack (first)
+     * @param {function} handler The event handler function
+     * @returns {self}
+     */
+    prepend(handler) {
+        this.handlers.unshift(handler);
+        return this;
+    }
+
+    /**
+     * Add handler at the bottom of the stack (last)
+     * @param {function} handler The event handler function
+     * @returns {self}
+     */
+    append(handler) {
+        this.handlers.push(handler);
+        return this;
+    }
+
+    /**
+     * Remove all existing handlers for this event
+     * @returns {self}
+     */
+    purge() {
+        this.handlers.length = 0;
+        return this;
+    }
+
+    /**
+     * Add handler to this custodian
+     * @param {string} type self event type
+     * @param {function} handler Error handler function
+     * @returns {self}
+     */
+    on(kind, handler) {
+        this.events.on(kind, handler);
+        return this;
+    }
+
+    /**
+     * Remove handler(s) to this custodian
+     * @param {string} type self event type
+     * @param {function} [handler] Error handler function
+     * @returns {self}
+     */
+    off(kind, handler) {
+        handler
+            ? this.events.removeListener(kind, handler)
+            : this.events.removeAllListeners(kind)
+        ;
+        return this;
+    }
+};

--- a/index.js
+++ b/index.js
@@ -124,21 +124,21 @@ module.exports = class Custodian {
         this.override({
             aliases: [ 'prependOnceListener' ],
             implementation: (type, handler) => {
-                function onceHandler(...args) {
-                    this.emitter.removeListener(onceHandler);
+                const onceHandler = (...args) => {
+                    this.emitter.removeListener(this.type, onceHandler);
                     handler.apply(this, args);
-                }
-                this.handlers.unshift(onceHandler);
+                };
+                this.emitter.prependListener(this.type, onceHandler);
             }
         });
 
         this.override({
             aliases: [ 'once' ],
             implementation: (type, handler) => {
-                function onceHandler(...args) {
-                    this.emitter.removeListener(onceHandler);
+                const onceHandler = (...args) => {
+                    this.emitter.removeListener(this.type, onceHandler);
                     handler.apply(this, args);
-                }
+                };
                 this.handlers.push(onceHandler);
             }
         });
@@ -172,7 +172,7 @@ module.exports = class Custodian {
                 this.emitter[alias] = (...args) => {
                     const [ type ] = args;
                     if (type !== this.type) {
-                        return this.mounted[alias].apply(this.emitter, args);
+                        return this.mounted[alias].call(this.emitter, this.type, ...args);
                     }
                     implementation.apply(this, args);
                     return this.emitter;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "event-custodian",
-  "version": "0.0.0",
-  "description": "Take responsibility for listeners on event emitter and look after them",
+  "version": "1.0.0",
+  "description": "📆 Take responsibility for listeners on event emitter and look after them",
   "keywords": [
     "EventEmitter",
     "listeners",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "handlers",
     "process",
     "unhandledRejection",
+    "Custodian",
     "📆"
   ],
   "author": "Fiverr SRE",
@@ -24,7 +25,6 @@
   },
   "devDependencies": {
     "@fiverr/eslint-config-fiverr": "^3.2.0",
-    "@lets/wait": "^2.0.2",
     "eslint": "^7.9.0",
     "eslint-plugin-log": "^1.2.6",
     "jest": "^26.4.2"

--- a/spec.js
+++ b/spec.js
@@ -93,7 +93,7 @@ describe('event-custodian', () => {
         ];
         const emitter = new EventEmitter();
         handlers.forEach((handler) => emitter[add]('event', handler));
-        const custodian = new Custodian(emitter, 'event').mount();
+        new Custodian(emitter, 'event').mount();
         emitter.emit('event');
         expect(results).toEqual([
             'one', 'two', 'three'

--- a/spec.js
+++ b/spec.js
@@ -82,35 +82,27 @@ describe('event-custodian', () => {
         ]);
     });
 
-    test('remove event handler', () => {
-        const { emitter } = basic();
-        const handler = () => results.push('three')
-        emitter.on('event', handler);
+    test.each([
+        [ 'on', 'off' ],
+        [ 'addListener', 'removeListener' ]
+    ])('Add and remove listeners using %s and %s', (add, remove) => {
+        const handlers = [
+            () => results.push('one'),
+            () => results.push('two'),
+            () => results.push('three')
+        ];
+        const emitter = new EventEmitter();
+        handlers.forEach((handler) => emitter[add]('event', handler));
+        const custodian = new Custodian(emitter, 'event').mount();
         emitter.emit('event');
         expect(results).toEqual([
             'one', 'two', 'three'
         ]);
-        emitter.off('event', handler);
+        emitter[remove]('event', handlers[1]);
         emitter.emit('event');
         expect(results).toEqual([
             'one', 'two', 'three',
-            'one', 'two'
-        ]);
-    });
-
-    test('and and remove event handler with addListener and removeListener', () => {
-        const { emitter } = basic();
-        const handler = () => results.push('three')
-        emitter.addListener('event', handler);
-        emitter.emit('event');
-        expect(results).toEqual([
-            'one', 'two', 'three'
-        ]);
-        emitter.removeListener('event', handler);
-        emitter.emit('event');
-        expect(results).toEqual([
-            'one', 'two', 'three',
-            'one', 'two'
+            'one', 'three'
         ]);
     });
 
@@ -128,7 +120,7 @@ describe('event-custodian', () => {
         ]);
     });
 
-    xtest('prepend event handler once', () => {
+    test('prepend event handler once', () => {
         const { emitter } = basic();
         emitter.prependListener('event', () => results.push('three'), { once: true });
         emitter.emit('event');
@@ -142,7 +134,7 @@ describe('event-custodian', () => {
         ]);
     });
 
-    xtest('prependOnce event handler', () => {
+    test('prependOnce event handler', () => {
         const { emitter } = basic();
         emitter.prependOnceListener('event', () => results.push('three'));
         emitter.emit('event');

--- a/spec.js
+++ b/spec.js
@@ -1,4 +1,189 @@
+const EventEmitter = require('events');
+const wait = require('@lets/wait');
+const Custodian = require('.');
+
+const existing = [];
+const results = [];
+const errors = [];
+
 describe('event-custodian', () => {
-    test('something', () => {
+    beforeAll(
+        () => existing.push(...process.listeners('unhandledRejection'))
+    );
+    afterEach(() => {
+        results.length = 0;
+        errors.length = 0;
+    });
+    afterAll(
+        () => existing.forEach(
+            (handler) => process.on(
+                'unhandledRejection',
+                handler
+            )
+        )
+    );
+
+    test('replace all event listeners with one', () => {
+        expect(process.listeners('unhandledRejection')).toHaveLength(existing.length);
+        process.on('unhandledRejection', () => results.push('I am here'));
+        process.on('unhandledRejection', () => results.push('And I am also here'));
+        expect(process.listeners('unhandledRejection')).toHaveLength(existing.length + 2);
+        new Custodian(process, 'unhandledRejection');
+        expect(process.listeners('unhandledRejection')).toHaveLength(1);
+    });
+
+    test('avoid unhandledRejection loopback', () => {
+        jest.spyOn(console, 'error');
+        const error = new Error('Something must have gone horribly wrong');
+        process.on('unhandledRejection', () => { throw error; });
+        new Custodian(process, 'unhandledRejection');
+        process.emit('unhandledRejection', new Error('something'));
+        expect(console.error).toBeCalledWith(error);
+    });
+
+    test('add event handler first', () => {
+        const emitter = new EventEmitter();
+        emitter.on('event', () => results.push('I am here'));
+        emitter.on('event', () => results.push('And I am also here'));
+
+        const custodian = new Custodian(emitter, 'event');
+        custodian.prepend(() => results.push('I am first'));
+
+        emitter.emit('event');
+        expect(results).toEqual([
+            'I am first',
+            'I am here',
+            'And I am also here'
+        ]);
+    });
+
+    test('add event handler last', () => {
+        const emitter = new EventEmitter();
+        emitter.on('event', () => results.push('I am here'));
+        emitter.on('event', () => results.push('And I am also here'));
+
+        const custodian = new Custodian(emitter, 'event');
+        custodian.append(() => results.push('I am last'));
+
+        emitter.emit('event');
+        expect(results).toEqual([
+            'I am here',
+            'And I am also here',
+            'I am last'
+        ]);
+    });
+
+    test('new handlers are pulled into the custodian', async() => {
+        const emitter = new EventEmitter();
+        emitter.on('event', () => results.push('I am here'));
+        emitter.on('event', () => results.push('And I am also here'));
+        new Custodian(emitter, 'event');
+
+        emitter.on('event', () => results.push('And finally, we were three'));
+        expect(emitter.listeners('event')).toHaveLength(2);
+        await wait(10);
+        expect(emitter.listeners('event')).toHaveLength(1);
+
+        emitter.emit('event');
+        expect(results).toEqual([
+            'I am here',
+            'And I am also here',
+            'And finally, we were three'
+        ]);
+    });
+
+    test('purge all existing listeners', () => {
+        const emitter = new EventEmitter();
+        emitter.on('event', () => results.push('I am here'));
+        emitter.on('event', () => results.push('And I am also here'));
+        const custodian = new Custodian(emitter, 'event');
+        custodian.purge();
+
+        emitter.emit('event');
+        expect(results).toHaveLength(0);
+    });
+
+    test('handlers isolation, errors are caught and reported', () => {
+        const emitter = new EventEmitter();
+        emitter.on('event', () => results.push('I am here'));
+        emitter.on('event', () => results.push('And I am also here'));
+        emitter.on('event', () => {
+            throw new Error('Something must have gone horribly wrong');
+        });
+        emitter.on('event', () => results.push('And finally, we were three'));
+        const custodian = new Custodian(emitter, 'event');
+        custodian.on('error', (error) => {
+            expect(error.message).toBe('Something must have gone horribly wrong');
+            errors.push(error);
+        });
+
+        emitter.emit('event');
+        expect(results).toEqual([
+            'I am here',
+            'And I am also here',
+            'And finally, we were three'
+        ]);
+        expect(errors).toHaveLength(1);
+    });
+
+    test('no error handler trigger unhandled error', () => {
+        const emitter = new EventEmitter();
+        emitter.on('event', () => {
+            throw new Error('Something must have gone horribly wrong');
+        });
+        new Custodian(emitter, 'event');
+        expect(() => emitter.emit('event')).toThrow();
+        try {
+            emitter.emit('event');
+        } catch ({ code }) {
+            expect(code).toBe('ERR_UNHANDLED_ERROR');
+        }
+    });
+
+    test('removal of error handler', () => {
+        const second = [];
+        const third = [];
+        const emitter = new EventEmitter();
+        emitter.on('event', () => {
+            throw new Error('Something must have gone horribly wrong');
+        });
+        const custodian = new Custodian(emitter, 'event');
+        custodian.on('error', (error) => errors.push(error));
+
+        emitter.emit('event');
+        expect(errors).toHaveLength(1);
+        expect(second).toHaveLength(0);
+        expect(third).toHaveLength(0);
+
+        custodian.on('error', (error) => second.push(error));
+        emitter.emit('event');
+        expect(errors).toHaveLength(2);
+        expect(second).toHaveLength(1);
+        expect(third).toHaveLength(0);
+
+        custodian.off('error');
+        custodian.on('error', (error) => third.push(error));
+        emitter.emit('event');
+        expect(errors).toHaveLength(2);
+        expect(second).toHaveLength(1);
+        expect(third).toHaveLength(1);
+    });
+
+    test('function chaining', () => {
+        const emitter = new EventEmitter();
+        emitter.on('event', () => results.push('I am here'));
+        emitter.on('event', () => results.push('And I am also here'));
+        new Custodian(emitter, 'event')
+            .purge()
+            .on('error', () => null)
+            .append(() => results.push('I am last'))
+            .prepend(() => results.push('I am first'))
+        ;
+
+        emitter.emit('event');
+        expect(results).toEqual([
+            'I am first',
+            'I am last'
+        ]);
     });
 });


### PR DESCRIPTION
Motivation by the following issue:

> Saying ur service uses this package: cld3-asm  (encountered a lot)
> on each uncaught exception in the server:
> - your process will shut down
> - without sending logs
> - without alerts anything
> - without send a beforeExit or an exit event before exiting
> - the unhandledRejection  we are setting in the service won't be called

Example from an irresponsible package

| ![](https://user-images.githubusercontent.com/516342/93642014-05117780-fa06-11ea-9b01-bfe8c8e24456.png)
| -

It will always throw as error inside the unhandledRejection handler, which will exit the process on SIGTERM

Packages should respect the recommendations

| ![](https://user-images.githubusercontent.com/516342/93642098-27a39080-fa06-11ea-95ab-6118ce1d04ae.png)
| -

but since they don't...

See readme. It's everything else